### PR TITLE
Create the generator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+; Unix-style newlines
+[*]
+indent_size = 2
+end_of_line = LF
+indent_style = space
+insert_final_newline = true

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules/**

--- a/default/get-name-from-config.js
+++ b/default/get-name-from-config.js
@@ -1,0 +1,14 @@
+var path = require('path');
+
+module.exports = function getNameFromConfig(rootPath) {
+  return new Promise(function(resolve) {
+    var name;
+
+    try {
+      var config = require(path.join(rootPath, '.yo-rc.json'));
+      name = config['donejs-heroku'] && config['donejs-heroku'].herokuAppName;
+    } catch (e) {}
+
+    resolve(name);
+  });
+};

--- a/default/index.js
+++ b/default/index.js
@@ -1,34 +1,136 @@
+var yaml = require('js-yaml');
+var last = require('lodash/last');
+var sortBy = require('lodash/sortBy');
 var Generator = require('yeoman-generator');
+var getNameFromConfig = require('./get-name-from-config');
 
 module.exports = Generator.extend({
-  constructor: function(args, opts) {
+  constructor: function constructor(args, opts) {
     Generator.call(this, args, opts);
-    this.pkg = this.fs.readJSON(this.destinationPath('package.json'), {});
-    
-    this.files = [
-      'file.js'
-    ];
+    this.travisConfigPath = this.destinationPath('.travis.yml');
+    this.herokuConfigPath = this.destinationPath('Procfile');
+    this.deploySettings = {
+      skip_cleanup: true, // jshint ignore:line
+      provider: 'heroku'
+    };
   },
 
-  prompting: function () {
-    var done = this.async();
+  initializing: function initializing() {
+    var travisConfigExists = this.fs.exists(this.travisConfigPath);
+    var herokuConfigExists = this.fs.exists(this.herokuConfigPath);
 
-    this.prompt([{
-      type    : 'input',
-      name    : 'name',
-      message : 'What is the name of the file?'
-    }]).then(function(answers) {
-      this.props = answers;
-      done();
-    }.bind(this));
+    if (!travisConfigExists) {
+      this.abort = true;
+      this.log.error(
+        'Travis config file not found!. Please run "donejs add travis" first.'
+      );
+      return;
+    }
+
+    this.travisYml = yaml.safeLoad(this.fs.read(this.travisConfigPath));
+    if (this.travisYml.deploy) {
+      this.abort = true;
+      this.log.error(
+        'There are deploy settings in your .travis.yml already. ' +
+          'Please delete the "deploy" section before running this command.'
+      );
+      return;
+    }
+
+    if (!herokuConfigExists) {
+      this.abort = true;
+      this.log.error(
+        'Heroku Procfile not found!. Please run "donejs add heroku" first.'
+      );
+      return;
+    }
   },
-  writing: function () {
-    this.log('Copying file to ' + this.destinationPath(this.props.name + '.js'));
-    
-    this.fs.copyTpl(
-			this.templatePath('file.js'),
-			this.destinationPath(this.props.name + '.js'),
-			this.props
-		);
+
+  prompting: function prompting() {
+    if (!this.abort) {
+      var self = this;
+      var done = self.async();
+
+      getNameFromConfig(this.destinationPath())
+        .then(function(name) {
+          return name ? name : self._getMostRecentHerokuAppName();
+        })
+        .then(function(name) {
+          return self.prompt([
+            {
+              type: 'input',
+              name: 'name',
+              message: 'What is the name of the Heroku application?',
+              default: name ? name : null
+            }
+          ]);
+        })
+        .then(function(answers) {
+          self.props = answers;
+          done();
+        });
+    }
+  },
+
+  writing: function writing() {
+    if (!this.abort) {
+      this.log('Adding deploy settings to ' + this.travisConfigPath);
+      this.travisYml.deploy = this.deploySettings;
+      this.travisYml.deploy.app = this.props.name;
+
+      this.fs.write(this.travisConfigPath, yaml.safeDump(this.travisYml));
+    }
+  },
+
+  _getMostRecentHerokuAppName: function getMostRecentHerokuAppName() {
+    return this._getHerokuApps()
+      .then(function(apps) {
+        return sortBy(apps, function(app) {
+          return new Date(app.created_at); // jshint ignore:line
+        });
+      })
+      .then(function(sorted) {
+        return sorted.length ? last(sorted).name : '';
+      });
+  },
+
+  _getHerokuApps: function getHerokuApps() {
+    var self = this;
+    var apps = '';
+
+    return new Promise(function(resolve) {
+      var timeout;
+
+      var child = self.spawnCommand('heroku', ['apps', '--json'], {
+        stdio: 'pipe'
+      });
+
+      var resolveEmpty = function resolveEmpty() {
+        clearTimeout(timeout);
+        resolve([]);
+      };
+
+      // resolve the promise if the process is taking too long,
+      // the user might be logged out
+      timeout = setTimeout(resolveEmpty, 2000);
+
+      child.stdout.on('data', function(data) {
+        apps += data;
+      });
+
+      child.on('exit', function(code) {
+        if (code === 0) {
+          try {
+            resolve(JSON.parse(apps));
+          } catch (e) {
+            resolveEmpty();
+          }
+        } else {
+          resolveEmpty();
+        }
+      });
+
+      child.on('error', resolveEmpty);
+    });
   }
 });

--- a/default/templates/file.js
+++ b/default/templates/file.js
@@ -1,3 +1,0 @@
-export default function() {
-  return 'This is a file from the donejs-travis-to-heroku DoneJS generator';
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,14 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
@@ -47,7 +55,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "balanced-match": {
@@ -61,9 +69,9 @@
       "integrity": "sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA=="
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -159,6 +167,13 @@
         "inherits": "2.0.3",
         "process-nextick-args": "1.0.7",
         "through2": "2.0.3"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        }
       }
     },
     "code-point-at": {
@@ -208,7 +223,7 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "requires": {
         "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "typedarray": "0.0.6"
       }
     },
@@ -254,6 +269,11 @@
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
     },
     "debug": {
       "version": "2.6.9",
@@ -333,9 +353,9 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
     "editions": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
-      "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
     },
     "ejs": {
       "version": "2.5.7",
@@ -369,6 +389,11 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
     },
     "exit": {
       "version": "0.1.2",
@@ -425,7 +450,7 @@
       "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
       "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
       "requires": {
-        "readable-stream": "2.3.3"
+        "readable-stream": "2.3.4"
       }
     },
     "formatio": {
@@ -446,6 +471,23 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "gh-got": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+      "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+      "requires": {
+        "got": "6.7.1",
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "github-username": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+      "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+      "requires": {
+        "gh-got": "5.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -479,6 +521,24 @@
         }
       }
     },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "unzip-response": "2.0.1",
+        "url-parse-lax": "1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -489,7 +549,7 @@
       "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.3.tgz",
       "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.5"
       }
     },
     "growl": {
@@ -507,9 +567,9 @@
       }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "hosted-git-info": {
@@ -587,7 +647,7 @@
         "cli-width": "2.2.0",
         "external-editor": "1.1.1",
         "figures": "1.7.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mute-stream": "0.0.6",
         "pinkie-promise": "2.0.1",
         "run-async": "2.3.0",
@@ -678,7 +738,7 @@
       "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
       "requires": {
         "binaryextensions": "2.1.1",
-        "editions": "1.3.3",
+        "editions": "1.3.4",
         "textextensions": "2.2.0"
       }
     },
@@ -704,6 +764,15 @@
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
+      }
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jshint": {
@@ -736,6 +805,17 @@
         }
       }
     },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -746,9 +826,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -833,9 +913,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
     "minimatch": {
@@ -843,7 +923,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1042,6 +1122,14 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1074,6 +1162,14 @@
         }
       }
     },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -1103,9 +1199,9 @@
       "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk="
     },
     "process-nextick-args": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -1128,15 +1224,34 @@
         }
       }
     },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      }
+    },
     "readable-stream": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
         "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
+        "process-nextick-args": "2.0.0",
         "safe-buffer": "5.1.1",
         "string_decoder": "1.0.3",
         "util-deprecate": "1.0.2"
@@ -1283,7 +1398,7 @@
         "path-to-regexp": "1.7.0",
         "samsam": "1.3.0",
         "text-encoding": "0.6.4",
-        "type-detect": "4.0.7"
+        "type-detect": "4.0.8"
       },
       "dependencies": {
         "diff": {
@@ -1320,6 +1435,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-template": {
       "version": "0.2.1",
@@ -1413,7 +1533,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "2.3.3",
+        "readable-stream": "2.3.4",
         "xtend": "4.0.1"
       }
     },
@@ -1437,9 +1557,9 @@
       "dev": true
     },
     "type-detect": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
-      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {
@@ -1592,7 +1712,7 @@
         "globby": "4.1.0",
         "grouped-queue": "0.3.3",
         "inquirer": "1.2.3",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "log-symbols": "1.0.2",
         "mem-fs": "1.1.3",
         "text-table": "0.2.0",
@@ -1650,7 +1770,7 @@
         "github-username": "3.0.0",
         "glob": "7.1.2",
         "istextorbinary": "2.2.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mem-fs-editor": "3.0.2",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
@@ -1666,94 +1786,6 @@
         "through2": "2.0.3",
         "user-home": "2.0.0",
         "yeoman-environment": "1.6.6"
-      },
-      "dependencies": {
-        "dateformat": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-        },
-        "gh-got": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
-          "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
-          "requires": {
-            "got": "6.7.1",
-            "is-plain-obj": "1.1.0"
-          }
-        },
-        "github-username": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
-          "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
-          "requires": {
-            "gh-got": "5.0.0"
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "requires": {
-            "create-error-class": "3.0.2",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-redirect": "1.0.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "lowercase-keys": "1.0.0",
-            "safe-buffer": "5.1.1",
-            "timed-out": "4.0.1",
-            "unzip-response": "2.0.1",
-            "url-parse-lax": "1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        }
       }
     },
     "yeoman-test": {
@@ -1763,7 +1795,7 @@
       "dev": true,
       "requires": {
         "inquirer": "3.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.5",
         "mkdirp": "0.5.1",
         "pinkie-promise": "2.0.1",
         "rimraf": "2.6.2",
@@ -1794,14 +1826,14 @@
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "cli-cursor": {
@@ -1855,12 +1887,12 @@
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "cli-cursor": "2.1.0",
             "cli-width": "2.2.0",
             "external-editor": "2.1.0",
             "figures": "2.0.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "mute-stream": "0.0.7",
             "run-async": "2.3.0",
             "rx-lite": "4.0.8",
@@ -1882,7 +1914,7 @@
           "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0"
+            "chalk": "2.3.1"
           }
         },
         "mute-stream": {
@@ -1897,7 +1929,7 @@
           "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
           "dev": true,
           "requires": {
-            "mimic-fn": "1.1.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "restore-cursor": {
@@ -1930,12 +1962,12 @@
           }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         },
         "tmp": {
@@ -1959,7 +1991,7 @@
           "integrity": "sha512-6/W7/B54OPHJXob0n0+pmkwFsirC8cokuQkPSmT/D0lCcSxkKtg/BA6ZnjUBIwjuGqmw3DTrT4en++htaUju5g==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.1",
             "debug": "3.1.0",
             "diff": "3.4.0",
             "escape-string-regexp": "1.0.5",
@@ -1967,7 +1999,7 @@
             "grouped-queue": "0.3.3",
             "inquirer": "3.3.0",
             "is-scoped": "1.0.0",
-            "lodash": "4.17.4",
+            "lodash": "4.17.5",
             "log-symbols": "2.2.0",
             "mem-fs": "1.1.3",
             "text-table": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "lib/",
   "scripts": {
     "test": "npm run jshint && npm run mocha",
-    "jshint": "jshint test/. default/index.js --config",
+    "jshint": "jshint . --config",
     "mocha": "mocha test/ --timeout 120000",
     "publish": "git push origin --tags && git push origin",
     "release:patch": "npm version patch && npm publish",
@@ -24,6 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "js-yaml": "^3.10.0",
     "lodash": "^4.17.4",
     "yeoman-generator": "^1.1.1"
   },

--- a/test/travis_deploy_fixture.yml
+++ b/test/travis_deploy_fixture.yml
@@ -1,0 +1,10 @@
+language: ruby
+rvm:
+  - 2.2
+  - jruby
+  - 2.0.0-p247
+deploy:
+  skip_cleanup: true
+  provider: heroku
+  app: my-awesome-app
+

--- a/test/travis_fixture.yml
+++ b/test/travis_fixture.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.2
+  - jruby
+  - 2.0.0-p247


### PR DESCRIPTION
Closes #2 

This generators runs a series of checks with early returns:

a) if there is no `.travis.yml` it fails with:
    `Travis config file not found!. Please run "donejs add travis" first`

b) if `.travis.yml` has deploy settings already, it fails with:
     `There are deploy settings in your .travis.yml already. Please delete the "deploy" section before running this command` 
     (@matthewp I'm not sure about this message, ideas?)

c) if there is no Procfile, it fails with:
    `Heroku Procfile not found!. Please run "donejs add heroku" first.`

if all checks pass, then it prompts the user to type the heroku app name, it runs

`heroku apps --json`

sorts the result by `created_at` date and returns the most recent name (which for guide users should be THE name) and uses it as the default for the prompt. 

`? What is the name of the Heroku application? (secret-thicket-26115)`

Thoughts?

PS: Another detail, the YAML parser I'm using strips unnecessary `"` from the yaml, that introduces some noise in the `.travis.yml` diff `donejs add heroku-to-travis` generates.... Wondering if we should strip those in advance from `donejs-travis` so the diff only includes the `deploy` section. 

